### PR TITLE
LEAN Exits Gracefully If The Algorithm Adds Invalid Symbol

### DIFF
--- a/QuantConnect.OandaBrokerage.Tests/OandaBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.OandaBrokerage.Tests/OandaBrokerageHistoryProviderTests.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false, new DataPermissionManager()));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false, new DataPermissionManager(), null));
 
                 var now = DateTime.UtcNow;
 

--- a/QuantConnect.OandaBrokerage/OandaRestApiBase.cs
+++ b/QuantConnect.OandaBrokerage/OandaRestApiBase.cs
@@ -419,9 +419,18 @@ namespace QuantConnect.Brokerages.Oanda
         /// <param name="symbolsToSubscribe">The list of symbols to subscribe</param>
         protected void SubscribeSymbols(IEnumerable<Symbol> symbolsToSubscribe)
         {
-            var instruments = symbolsToSubscribe
-                .Select(symbol => SymbolMapper.GetBrokerageSymbol(symbol))
-                .ToList();
+            var instruments = new List<string>();
+
+            try
+            {
+                instruments.AddRange(symbolsToSubscribe
+                    .Select(SymbolMapper.GetBrokerageSymbol));
+            }
+            catch (Exception e)
+            {
+                // GetBrokerageSymbol will raise an exception if at least one invalid symbol, e.g. GPBEUR, is requested
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, -1, e.Message));
+            }
 
             PricingConnectionHandler.EnableMonitoring(false);
 


### PR DESCRIPTION
#### Description
If the algorithm adds an invalid symbol, e.g. GPBEUR, an exception is raised. However, LEAN doesn't exit because the operation is not done in the main thread, but stops getting data if there are valid symbols.
We added a brokerage error message to exit LEAN.

#### Related Issue
N/A

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
Local live deployment. This doesn't affect QuantConnect Cloud because data comes from QuantConnect data provider.
```csharp
AddForex("GPBEUR");
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`