### PR TITLE
Return null on unsupported history and data download requests

### DIFF
--- a/QuantConnect.OandaBrokerage.Tests/OandaBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.OandaBrokerage.Tests/OandaBrokerageHistoryProviderTests.cs
@@ -40,35 +40,35 @@ namespace QuantConnect.Tests.Brokerages.Oanda
                 return new[]
                 {
                     // valid parameters
-                    new TestCaseData(eurusd, Resolution.Second, Time.OneMinute, TickType.Quote, false, false),
-                    new TestCaseData(eurusd, Resolution.Minute, Time.OneHour, TickType.Quote, false, false),
-                    new TestCaseData(eurusd, Resolution.Hour, Time.OneDay, TickType.Quote, false, false),
-                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, false, false),
+                    new TestCaseData(eurusd, Resolution.Second, Time.OneMinute, TickType.Quote, false),
+                    new TestCaseData(eurusd, Resolution.Minute, Time.OneHour, TickType.Quote, false),
+                    new TestCaseData(eurusd, Resolution.Hour, Time.OneDay, TickType.Quote, false),
+                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, false),
 
                     // invalid resolution, null result
-                    new TestCaseData(eurusd, Resolution.Tick, TimeSpan.FromSeconds(15), TickType.Quote, false, true),
+                    new TestCaseData(eurusd, Resolution.Tick, TimeSpan.FromSeconds(15), TickType.Quote, true),
 
-                    // invalid period, no error, empty result
-                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(-15), TickType.Quote, true, false),
+                    // invalid period, null result
+                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(-15), TickType.Quote, true),
 
                     // invalid symbol, null result
-                    new TestCaseData(Symbol.Create("XYZ", SecurityType.Forex, Market.FXCM), Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, false, true),
+                    new TestCaseData(Symbol.Create("XYZ", SecurityType.Forex, Market.FXCM), Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, true),
 
                     // invalid security type, null result
-                    new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, false, true),
+                    new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, true),
 
                     // invalid market, null result
-                    new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.USA), Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, false, true),
+                    new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.USA), Resolution.Daily, TimeSpan.FromDays(15), TickType.Quote, true),
 
                     // invalid tick type, null result
-                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, false, true),
-                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(15), TickType.OpenInterest, false, true),
+                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade, true),
+                    new TestCaseData(eurusd, Resolution.Daily, TimeSpan.FromDays(15), TickType.OpenInterest, true),
                 };
             }
         }
 
         [Test, TestCaseSource(nameof(TestParameters))]
-        public void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType, bool shouldBeEmpty, bool unsupported)
+        public void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType, bool unsupported)
         {
             var environment = Config.Get("oanda-environment").ConvertTo<Environment>();
             var accessToken = Config.Get("oanda-access-token");
@@ -98,11 +98,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
                 return;
             }
 
-            if (shouldBeEmpty)
-            {
-                Assert.IsEmpty(history);
-                return;
-            }
+            Assert.IsNotNull(history);
 
             foreach (var bar in history.Cast<QuoteBar>())
             {

--- a/QuantConnect.OandaBrokerage.Tests/OandaBrokerageTests.cs
+++ b/QuantConnect.OandaBrokerage.Tests/OandaBrokerageTests.cs
@@ -55,12 +55,17 @@ namespace QuantConnect.Tests.Brokerages.Oanda
         /// <summary>
         /// Provides the data required to test each order type in various cases
         /// </summary>
-        public static TestCaseData[] OrderParameters => new[]
+        public static IEnumerable<TestCaseData> OrderParameters
         {
-            new TestCaseData(new MarketOrderTestParameters(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda))).SetName("MarketOrder"),
-            new TestCaseData(new LimitOrderTestParameters(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), 5m, 0.32m)).SetName("LimitOrder"),
-            new TestCaseData(new StopMarketOrderTestParameters(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), 5m, 0.32m)).SetName("StopMarketOrder")
-        };
+            get
+            {
+                TestGlobals.Initialize();
+
+                yield return new TestCaseData(new MarketOrderTestParameters(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda))).SetName("MarketOrder");
+                yield return new TestCaseData(new LimitOrderTestParameters(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), 5m, 0.32m)).SetName("LimitOrder");
+                yield return new TestCaseData(new StopMarketOrderTestParameters(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), 5m, 0.32m)).SetName("StopMarketOrder");
+            }
+        }
 
         /// <summary>
         ///     Gets the symbol to be traded, must be shortable
@@ -107,7 +112,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
                     {
                         order.Status = orderEvent.Status;
                         orders[order.Id] = order;
-                    }   
+                    }
                 }
             };
             oanda.OrdersStatusChanged += orderStatusChangedCallback;

--- a/QuantConnect.OandaBrokerage.ToolBox/OandaDataDownloader.cs
+++ b/QuantConnect.OandaBrokerage.ToolBox/OandaDataDownloader.cs
@@ -102,6 +102,12 @@ namespace QuantConnect.ToolBox.OandaDownloader
                 return null;
             }
 
+            if (dataDownloaderGetParameters.StartUtc >= dataDownloaderGetParameters.EndUtc)
+            {
+                Logging.Log.Trace("OandaDataDownloader.Get(): The history request start date must precede the end date, no history returned");
+                return null;
+            }
+
             return GetData(dataDownloaderGetParameters);
         }
 

--- a/QuantConnect.OandaBrokerage.ToolBox/OandaDataDownloader.cs
+++ b/QuantConnect.OandaBrokerage.ToolBox/OandaDataDownloader.cs
@@ -76,26 +76,41 @@ namespace QuantConnect.ToolBox.OandaDownloader
         {
             var symbol = dataDownloaderGetParameters.Symbol;
             var resolution = dataDownloaderGetParameters.Resolution;
-            var startUtc = dataDownloaderGetParameters.StartUtc;
-            var endUtc = dataDownloaderGetParameters.EndUtc;
             var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Quote)
             {
-                yield break;
+                Logging.Log.Trace("OandaDataDownloader.Get(): Unsupported tick type: " + tickType);
+                return null;
             }
 
             if (!_symbolMapper.IsKnownLeanSymbol(symbol))
-                throw new ArgumentException("Invalid symbol requested: " + symbol.Value);
+            {
+                Logging.Log.Trace("OandaDataDownloader.Get(): Unsupported symbol: " + symbol);
+                return null;
+            }
 
             if (resolution == Resolution.Tick)
-                throw new NotSupportedException("Resolution not available: " + resolution);
+            {
+                Logging.Log.Trace("OandaDataDownloader.Get(): Unsupported resolution: " + resolution);
+                return null;
+            }
 
             if (symbol.ID.SecurityType != SecurityType.Forex && symbol.ID.SecurityType != SecurityType.Cfd)
-                throw new NotSupportedException("SecurityType not available: " + symbol.ID.SecurityType);
+            {
+                Logging.Log.Trace("OandaDataDownloader.Get(): Unsupported security type: " + symbol.ID.SecurityType);
+                return null;
+            }
 
-            if (endUtc < startUtc)
-                throw new ArgumentException("The end date must be greater or equal than the start date.");
+            return GetData(dataDownloaderGetParameters);
+        }
+
+        private IEnumerable<BaseData> GetData(DataDownloaderGetParameters parameters)
+        {
+            var symbol = parameters.Symbol;
+            var resolution = parameters.Resolution;
+            var startUtc = parameters.StartUtc;
+            var endUtc = parameters.EndUtc;
 
             var barsTotalInPeriod = new List<QuoteBar>();
             var barsToSave = new List<QuoteBar>();
@@ -175,7 +190,7 @@ namespace QuantConnect.ToolBox.OandaDownloader
                     break;
             }
         }
-        
+
 
         /// <summary>
         /// Groups a list of bars into a dictionary keyed by date

--- a/QuantConnect.OandaBrokerage.ToolBox/OandaDownloaderProgram.cs
+++ b/QuantConnect.OandaBrokerage.ToolBox/OandaDownloaderProgram.cs
@@ -67,6 +67,10 @@ namespace QuantConnect.ToolBox.OandaDownloader
                     var symbol = Symbol.Create(ticker, securityType, market);
 
                     var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, startDate, endDate, TickType.Quote));
+                    if (data == null)
+                    {
+                        continue;
+                    }
 
                     if (allResolutions)
                     {

--- a/QuantConnect.OandaBrokerage/OandaBrokerage.cs
+++ b/QuantConnect.OandaBrokerage/OandaBrokerage.cs
@@ -54,6 +54,7 @@ namespace QuantConnect.Brokerages.Oanda
         private bool _unsupportedAssetForHistoryLogged;
         private bool _unsupportedResolutionForHistoryLogged;
         private bool _unsupportedTickTypeForHistoryLogged;
+        private bool _invalidTimeRangeHistoryLogged;
 
         /// <summary>
         /// The maximum number of bars per historical data request
@@ -251,6 +252,17 @@ namespace QuantConnect.Brokerages.Oanda
                     Log.Trace($"OandaBrokerage.GetHistory(): Unsupported tick type: {request.TickType}, no history returned");
                     _unsupportedTickTypeForHistoryLogged = true;
                 }
+                return null;
+            }
+
+            if (request.StartTimeUtc >= request.EndTimeUtc)
+            {
+                if (!_invalidTimeRangeHistoryLogged)
+                {
+                    Log.Trace("OandaBrokerage.GetHistory(): The request start date must precede the end date, no history returned.");
+                    _invalidTimeRangeHistoryLogged = true;
+                }
+
                 return null;
             }
 

--- a/QuantConnect.OandaBrokerage/OandaRestApiBase.cs
+++ b/QuantConnect.OandaBrokerage/OandaRestApiBase.cs
@@ -397,14 +397,14 @@ namespace QuantConnect.Brokerages.Oanda
         /// <summary>
         /// Returns true if this brokerage supports the specified symbol
         /// </summary>
-        private bool CanSubscribe(Symbol symbol)
+        public bool CanSubscribe(Symbol symbol)
         {
-            // ignore unsupported security types
-            if (symbol.ID.SecurityType != SecurityType.Forex && symbol.ID.SecurityType != SecurityType.Cfd)
-                return false;
-
-            // ignore universe symbols
-            return !symbol.Value.Contains("-UNIVERSE-") && symbol.ID.Market == Market.Oanda;
+            return
+                // ignore unsupported security types
+                (symbol.ID.SecurityType == SecurityType.Forex || symbol.ID.SecurityType == SecurityType.Cfd) &&
+                // ignore universe symbols
+                !symbol.Value.Contains("-UNIVERSE-") &&
+                symbol.ID.Market == Market.Oanda;
         }
 
         private bool Refresh()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
