### PR TITLE
Fix: add retry logic to `StreamSession.GetSession()`

### DIFF
--- a/QuantConnect.OandaBrokerage/RestV20/Session/StreamSession.cs
+++ b/QuantConnect.OandaBrokerage/RestV20/Session/StreamSession.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using QuantConnect.Logging;
 
@@ -26,6 +27,8 @@ namespace Oanda.RestV20.Session
     /// </summary>
     public abstract class StreamSession
     {
+        private const int MaxRetries = 5;
+        private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(2);
         private WebResponse _response;
         private bool _shutdown;
         private Task _runningTask;
@@ -46,13 +49,34 @@ namespace Oanda.RestV20.Session
         protected abstract WebResponse GetSession();
 
         /// <summary>
+        /// Calls <see cref="GetSession"/> with linear backoff retry up to <see cref="MaxRetries"/> attempts.
+        /// </summary>
+        private WebResponse GetSessionWithRetry()
+        {
+            for (var attempt = 1; attempt <= MaxRetries; attempt++)
+            {
+                try
+                {
+                    return GetSession();
+                }
+                catch (Exception ex) when (attempt < MaxRetries)
+                {
+                    var delay = TimeSpan.FromSeconds(RetryDelay.TotalSeconds * attempt);
+                    Log.Error($"StreamSession.GetSessionWithRetry(): attempt {attempt}/{MaxRetries} failed: {ex.Message}. Retrying in {delay.TotalSeconds}s.");
+                    Thread.Sleep(delay);
+                }
+            }
+            return GetSession();
+        }
+
+        /// <summary>
         /// Starts the session
         /// </summary>
         public void StartSession()
         {
             _shutdown = false;
 
-            _response = GetSession();
+            _response = GetSessionWithRetry();
 
             _runningTask = Task.Factory.StartNew(() =>
             {


### PR DESCRIPTION
#### Description
Introduces `GetSessionWithRetry()` in `StreamSession` which wraps `GetSession()` with up to 5 attempts using linear backoff (2s x attempt).

#### Related PRs
- #30 

#### Related Issue
The internal issue.

#### Motivation and Context
Fix the bug.

#### Requires Documentation Change
N/a

#### How Has This Been Tested?
<img width="1875" height="499" alt="image" src="https://github.com/user-attachments/assets/8c309287-1031-4078-baac-63bca175359f" />

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
